### PR TITLE
Allow to use virtualenv environment instead of only conda in sbatch.py

### DIFF
--- a/configs/sbatch/alex.hernandez-garcia.yaml
+++ b/configs/sbatch/alex.hernandez-garcia.yaml
@@ -1,0 +1,4 @@
+# Overwrites defaults.yaml for user `schmidtv`.
+# Create your own $USER.yaml in order to overwrite defaults.yaml systematically to your own taste.
+virtualenv: True
+env: /home/mila/a/alex.hernandez-garcia/.virtualenvs/ocp-torch1110cuda102


### PR DESCRIPTION
Currently only conda environments are supported. This small PR allows to activate a virtualenv `env` by specifying `virtualenv=True`. If `False` or doesn't exist, then it defaults to conda.

Note: IMO the environment should be setup from scratch in `$SLURM_TMPDIR` instead of activated from a "home" environment. And IMO too, it should be a virtualenv environment, not conda ;)