### PR TITLE
download oc20-dense

### DIFF
--- a/scripts/download_data.py
+++ b/scripts/download_data.py
@@ -25,6 +25,7 @@ DOWNLOAD_LINKS = {
         "md": "https://dl.fbaipublicfiles.com/opencatalystproject/data/s2ef_md.tar",
     },
     "is2re": "https://dl.fbaipublicfiles.com/opencatalystproject/data/is2res_train_val_test_lmdbs.tar.gz",
+    "dense": "oc20_dense_data.tar.gz",
 }
 
 S2EF_COUNTS = {
@@ -56,6 +57,9 @@ def get_data(datadir, task, split, del_intmd_files, inputdir):
         download_link = DOWNLOAD_LINKS[task][split]
 
     elif task == "is2re":
+        download_link = DOWNLOAD_LINKS[task]
+
+    elif task == "dense":
         download_link = DOWNLOAD_LINKS[task]
 
     if inputdir is None:


### PR DESCRIPTION
Decompress the OC20-Dense dataset using
`python scripts/download_data.py -m scripts.download_data --input-path=/network/datasets/oc20.var/oc20_dense/ --task=dense --data-path=/network/scratch/s/schmidtv/ocp/datasets/ocp/dense/`